### PR TITLE
Upgraded Guice to 4.2.3 to fix exceptions in Java 9+

### DIFF
--- a/sdk-services/pom.xml
+++ b/sdk-services/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
-            <version>4.1.0</version>
+            <version>4.2.3</version>
         </dependency>
         <dependency>
             <groupId>commons-fileupload</groupId>


### PR DESCRIPTION
When running a service under Java 9+, and that service has a provisioning error in Guice, the exception stack is all messed up and entirely unhelpful due to some kind of bytecode changes.

Upgrading Guice to the latest version (4.2.3) fixes these bytecode changes and the correct provisioning exceptions bubble up.